### PR TITLE
Customize Upstart script block

### DIFF
--- a/templates/tasseo.conf.j2
+++ b/templates/tasseo.conf.j2
@@ -7,6 +7,8 @@ respawn
 setuid tasseo
 chdir {{ tasseo_dir }}/tasseo-{{ tasseo_version }}
 
-env GRAPHITE_URL={{ tasseo_graphite_url }}
+script
+  export GRAPHITE_URL="{{ tasseo_graphite_url }}"
 
-exec bundle exec rackup -I lib -p {{ tasseo_port }} -s thin >> {{ tasseo_log }} 2>&1
+  exec bundle exec rackup -I lib -p {{ tasseo_port }} -s thin >> {{ tasseo_log }} 2>&1
+end script


### PR DESCRIPTION
This changeset switches to an Upstart script block for the Tasseo Upstart script. This allows users to pass snippets of a script that get evaluated as the value for `tasseo_graphite_url`.

Example:

```
tasseo_graphite_url: "http://$(curl -s http://instance-data.ec2.internal/latest/meta-data/public-hostname):8080"
```

This would set the Graphite URL to the FQDN of an EC2 instance.
